### PR TITLE
Fix checkbox hover width bug

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -102,7 +102,7 @@
   flex-grow: 100;
 }
 
-.dynamic-highlights-settings .query-wrapper input {
+.dynamic-highlights-settings .query-wrapper input:not([type="checkbox"]) {
   flex-grow: 100;
   width: 15ch;
 }


### PR DESCRIPTION
without the additional condition, the selector also affects checkboxes; most notably it sometimes prevents from properly clicking the save button, since the regex-checkbox is too wide on hover.